### PR TITLE
Add callback function to NewChildMenu and make ADMINISTRATOR bypass other permission checks

### DIFF
--- a/discord_permissions.go
+++ b/discord_permissions.go
@@ -9,12 +9,13 @@ func permissionsWrapper(PermissionName string, PermissionsHex uint64) func(ctx *
 		if err != nil {
 			return err.Error(), false
 		}
-		if guild.OwnerID == ctx.Message.Author.ID {
-			return "", true
-		}
 		perms, err := ctx.Message.Member.GetPermissions(context.TODO(), ctx.Session)
 		if err != nil {
 			return err.Error(), false
+		}
+		// 0x00000008 is the ADMINISTRATOR permission's hex code.
+		if guild.OwnerID == ctx.Message.Author.ID || (perms&0x00000008) == 0x00000008 {
+			return "", true
 		}
 		return "You must have the  \"" + PermissionName + "\" permission to run this command.", (perms & PermissionsHex) == PermissionsHex
 	}

--- a/discord_permissions.go
+++ b/discord_permissions.go
@@ -9,14 +9,19 @@ func permissionsWrapper(PermissionName string, PermissionsHex uint64) func(ctx *
 		if err != nil {
 			return err.Error(), false
 		}
+		if guild.OwnerID == ctx.Message.Author.ID {
+			return "", true
+		}
 		perms, err := ctx.Message.Member.GetPermissions(context.TODO(), ctx.Session)
 		if err != nil {
 			return err.Error(), false
 		}
-		// 0x00000008 is the ADMINISTRATOR permission's hex code.
-		if guild.OwnerID == ctx.Message.Author.ID || (perms&0x00000008) == 0x00000008 {
+
+		// 0x00000008 is the ADMINISTRATOR permission hex code and bypasses everything.
+		if (perms & 0x00000008) == 0x00000008 {
 			return "", true
 		}
+
 		return "You must have the  \"" + PermissionName + "\" permission to run this command.", (perms & PermissionsHex) == PermissionsHex
 	}
 }

--- a/embed_menus.go
+++ b/embed_menus.go
@@ -3,9 +3,10 @@ package gommand
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/andersfylling/disgord"
 	"github.com/andersfylling/snowflake/v4"
-	"sync"
 )
 
 // This is used to represent all of the current menus.
@@ -88,7 +89,7 @@ func (e *EmbedMenu) Display(ChannelID, MessageID snowflake.Snowflake, client dis
 }
 
 // NewChildMenu is used to create a new child menu.
-func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton) *EmbedMenu {
+func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, onDisplay func()) *EmbedMenu {
 	NewEmbedMenu := &EmbedMenu{
 		Reactions: &MenuReactions{
 			ReactionSlice: []MenuReaction{},
@@ -102,6 +103,7 @@ func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton) *EmbedMe
 		Function: func(ChannelID, MessageID snowflake.Snowflake, _ *EmbedMenu, client disgord.Session) {
 			_ = client.DeleteAllReactions(context.TODO(), ChannelID, MessageID)
 			_ = NewEmbedMenu.Display(ChannelID, MessageID, client)
+			go onDisplay()
 		},
 	}
 	e.Reactions.Add(Reaction)

--- a/embed_menus.go
+++ b/embed_menus.go
@@ -89,7 +89,7 @@ func (e *EmbedMenu) Display(ChannelID, MessageID snowflake.Snowflake, client dis
 }
 
 // NewChildMenu is used to create a new child menu.
-func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, onDisplay func()) *EmbedMenu {
+func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, callback func()) *EmbedMenu {
 	NewEmbedMenu := &EmbedMenu{
 		Reactions: &MenuReactions{
 			ReactionSlice: []MenuReaction{},
@@ -103,7 +103,7 @@ func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, onDispla
 		Function: func(ChannelID, MessageID snowflake.Snowflake, _ *EmbedMenu, client disgord.Session) {
 			_ = client.DeleteAllReactions(context.TODO(), ChannelID, MessageID)
 			_ = NewEmbedMenu.Display(ChannelID, MessageID, client)
-			go onDisplay()
+			go callback()
 		},
 	}
 	e.Reactions.Add(Reaction)

--- a/embed_menus.go
+++ b/embed_menus.go
@@ -30,7 +30,7 @@ type MenuButton struct {
 
 // MenuReaction represents the button and the function which it triggers.
 type MenuReaction struct {
-	Button   MenuButton
+	Button   *MenuButton
 	Function func(ChannelID, MessageID snowflake.Snowflake, _ *EmbedMenu, client disgord.Session)
 }
 
@@ -53,7 +53,7 @@ func (mr *MenuReactions) Add(reaction MenuReaction) {
 	mr.ReactionSlice = Slice
 }
 
-// AddParent is used to add a new parent menu.
+// AddParentMenu is used to add a new parent menu.
 func (e *EmbedMenu) AddParentMenu(Menu *EmbedMenu) {
 	e.parent = Menu
 }
@@ -88,22 +88,35 @@ func (e *EmbedMenu) Display(ChannelID, MessageID snowflake.Snowflake, client dis
 	return nil
 }
 
+// ChildMenuOptions are options which can be set when creating a child menu.
+type ChildMenuOptions struct {
+	Embed        *disgord.Embed `json:"embed"`
+	Button       *MenuButton    `json:"button"`
+	BeforeAction func()         `json:"-"`
+	AfterAction  func()         `json:"-"`
+}
+
 // NewChildMenu is used to create a new child menu.
-func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, callback func()) *EmbedMenu {
+func (e *EmbedMenu) NewChildMenu(options *ChildMenuOptions) *EmbedMenu {
 	NewEmbedMenu := &EmbedMenu{
 		Reactions: &MenuReactions{
 			ReactionSlice: []MenuReaction{},
 		},
-		Embed:    embed,
+		Embed:    options.Embed,
 		MenuInfo: e.MenuInfo,
 	}
 	NewEmbedMenu.parent = e
 	Reaction := MenuReaction{
-		Button: item,
+		Button: options.Button,
 		Function: func(ChannelID, MessageID snowflake.Snowflake, _ *EmbedMenu, client disgord.Session) {
+			if options.BeforeAction != nil {
+				options.BeforeAction()
+			}
 			_ = client.DeleteAllReactions(context.TODO(), ChannelID, MessageID)
 			_ = NewEmbedMenu.Display(ChannelID, MessageID, client)
-			go callback()
+			if options.AfterAction != nil {
+				options.AfterAction()
+			}
 		},
 	}
 	e.Reactions.Add(Reaction)
@@ -113,7 +126,7 @@ func (e *EmbedMenu) NewChildMenu(embed *disgord.Embed, item MenuButton, callback
 // AddBackButton is used to add a back Button to the page.
 func (e *EmbedMenu) AddBackButton() {
 	Reaction := MenuReaction{
-		Button: MenuButton{
+		Button: &MenuButton{
 			Description: "Goes back to the parent menu.",
 			Name:        "Back",
 			Emoji:       "⬆",

--- a/embeds_paginator.go
+++ b/embeds_paginator.go
@@ -3,9 +3,10 @@ package gommand
 import (
 	"context"
 	"errors"
+	"strconv"
+
 	"github.com/andersfylling/disgord"
 	"github.com/andersfylling/snowflake/v4"
-	"strconv"
 )
 
 // EmbedsPaginator is used to paginate together several embeds.
@@ -49,7 +50,7 @@ func EmbedsPaginator(ctx *Context, Pages []*disgord.Embed) error {
 				Emoji:       "▶️",
 				Name:        "Forward",
 				Description: "Goes forward a page.",
-			})
+			}, nil)
 			LastPage.Reactions.Add(MenuReaction{
 				Button: MenuButton{
 					Emoji:       "◀️",

--- a/embeds_paginator.go
+++ b/embeds_paginator.go
@@ -46,13 +46,16 @@ func EmbedsPaginator(ctx *Context, Pages []*disgord.Embed) error {
 			LastPage = FirstPage
 		} else {
 			PageBefore := LastPage
-			LastPage = LastPage.NewChildMenu(em, MenuButton{
-				Emoji:       "▶️",
-				Name:        "Forward",
-				Description: "Goes forward a page.",
-			}, nil)
+			LastPage = LastPage.NewChildMenu(&ChildMenuOptions{
+				Embed: em,
+				Button: &MenuButton{
+					Emoji:       "▶️",
+					Name:        "Forward",
+					Description: "Goes forward a page.",
+				},
+			})
 			LastPage.Reactions.Add(MenuReaction{
-				Button: MenuButton{
+				Button: &MenuButton{
 					Emoji:       "◀️",
 					Name:        "Back",
 					Description: "Goes back a page.",

--- a/example/main.go
+++ b/example/main.go
@@ -128,16 +128,20 @@ func init() {
 				Description: "Click the option below.",
 			}, ctx)
 
-			child := menu.NewChildMenu(&disgord.Embed{
-				Image: &disgord.EmbedImage{
-					URL: "https://cdn.vox-cdn.com/thumbor/s6HznC4HCYrV3axUS-7wVOPbC2c=/0x0:1020x680/2050x1367/cdn.vox-cdn.com/assets/3785529/DOGE-10.jpg",
+			child := menu.NewChildMenu(&gommand.ChildMenuOptions{
+				Embed: &disgord.Embed{
+					Image: &disgord.EmbedImage{
+						URL: "https://cdn.vox-cdn.com/thumbor/s6HznC4HCYrV3axUS-7wVOPbC2c=/0x0:1020x680/2050x1367/cdn.vox-cdn.com/assets/3785529/DOGE-10.jpg",
+					},
 				},
-			}, gommand.MenuButton{
-				Emoji:       "🇦",
-				Name:        "Show doge",
-				Description: "such doge such wow",
-			}, func() {
-				println("Doge was here!")
+				Button: &gommand.MenuButton{
+					Emoji:       "🇦",
+					Name:        "Show doge",
+					Description: "such doge such wow",
+				},
+				AfterAction: func() {
+					println("Doge was here!")
+				},
 			})
 			child.AddBackButton()
 

--- a/example/main.go
+++ b/example/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
+	"os"
+
 	"github.com/andersfylling/disgord"
 	"github.com/auttaja/gommand"
 	"github.com/sirupsen/logrus"
-	"os"
 )
 
 // Create the command router.
@@ -135,6 +136,8 @@ func init() {
 				Emoji:       "🇦",
 				Name:        "Show doge",
 				Description: "such doge such wow",
+			}, func() {
+				println("Doge was here!")
 			})
 			child.AddBackButton()
 


### PR DESCRIPTION
This PR allows you to add a callback function to be called when a child menu is displayed. It's particularly useful in contexts where you need to receive more input (e.g. a WaitForMessage).

This *is* breaking, so making it a variadic parameter or integrating it into a struct could be better.