### PR TITLE
Update deleted message handler.

### DIFF
--- a/disgord_command_events.go
+++ b/disgord_command_events.go
@@ -146,6 +146,7 @@ func (r *Router) Hook(s disgord.Session) {
 		s.On(disgord.EvtGuildCreate, r.DeletedMessageHandler.guildCreate)
 		s.On(disgord.EvtMessageCreate, r.DeletedMessageHandler.messageCreate)
 		s.On(disgord.EvtMessageDelete, r.DeletedMessageHandler.messageDelete)
+		s.On(disgord.EvtMessageUpdate, r.DeletedMessageHandler.messageUpdate)
 	}
 	s.On(disgord.EvtMessageReactionAdd, handleMenuReactionEdit)
 	s.On(disgord.EvtMessageDelete, handleEmbedMenuMessageDelete)

--- a/docs/handling-deleted-messages.md
+++ b/docs/handling-deleted-messages.md
@@ -5,6 +5,7 @@ For some bots, being able to track deleted messages in an easy to use way is imp
 - `Limit`: Defines the maximum amount of cached messages. -1 = unlimited (not suggested if it's in-memory since it'll lead to memory leaks), 0 = default, >0 = user set maximum. This should run on a First In First Out (FIFO) basis. By default, this will be set to 1,000 messages. Messages which have been purged due to this limit will not have an event fired for them.
 - `Callback`: The callback of type `func(s disgord.Session, msg *disgord.Message)` which is called when a message is deleted. As with commands, for ease of use the `Member` attribute is set on the message.
 - `MessageCacheStorageAdapter`: The [message cache storage adapter](./message-cache-storage-adapter.md) which is used for this. If this is not set, it will default to the built-in in-memory caching adapter.
+- `IgnoreBots`: Defines whether or not messages from bots should be excluded from cache. Defaults to false, meaning messages from bots will be cached.
 
 ## Message cache storage adapter
 By default (like other libraries such as discord.py), gommand keeps a finite amount of messages cached into RAM which is set by the user in the deleted message handler parameters (or defaults to 1,000). However, if you wish to store these in a database somewhere (normally for memory management purposes), you will likely want to want to write your own message caching adapter. In gommand, memory cachers use the `gommand.MemoryCacheStorageAdapter` interface. This contains the following functions which need to be set:
@@ -15,6 +16,7 @@ By default (like other libraries such as discord.py), gommand keeps a finite amo
 - `DeleteChannelsMessages(ChannelID disgord.Snowflake)`: Deletes all messages cached for a specific channel.
 - `Set(ChannelID, MessageID disgord.Snowflake, Message *disgord.Message, Limit uint)`: Sets an item in the cache. The limit is passed through so that you can implement a simple First In First Out (FIFO) caching system. The limit will be 0 if it is set to unlimited.
 - `RemoveGuild(GuildID disgord.Snowflake)`: The behaviour of this function depends on if the below functions are set. If they are, this function should remove all channel ID relationships with a specific guild ID, but not messages. If they are not, it should remove all messages relating to the specific guild ID.
+- `Update(ChannelID, MessageID disgord.Snowflake, Message *disgord.Message)`: Updates the message in cache, from a message edit for example.
 
 The following manage storing channel/guild ID relationships. This is important in some K/V cache types so that if a guild is removed, we know what channel ID's to purge from the cache. These are optional and do not need to be set:
 

--- a/in_memory_message_cache_storage_adapter.go
+++ b/in_memory_message_cache_storage_adapter.go
@@ -201,3 +201,22 @@ func (c *InMemoryMessageCacheStorageAdapter) Set(ChannelID, MessageID disgord.Sn
 	// Write unlock the cache.
 	c.lock.Unlock()
 }
+
+// Update is used to update an item in the cache.
+func (c *InMemoryMessageCacheStorageAdapter) Update(ChannelID, MessageID disgord.Snowflake, Message *disgord.Message) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	msgs := c.cache[ChannelID]
+	if msgs == nil {
+		// This channel isn't cached, return here.
+		return
+	}
+
+	if _, ok := (*msgs)[MessageID]; !ok {
+		// This message wasn't cached, return here.
+		return
+	}
+
+	(*c.cache[ChannelID])[MessageID].msg = Message
+}

--- a/in_memory_message_cache_storage_adapter.go
+++ b/in_memory_message_cache_storage_adapter.go
@@ -218,5 +218,5 @@ func (c *InMemoryMessageCacheStorageAdapter) Update(ChannelID, MessageID disgord
 		return
 	}
 
-	(*c.cache[ChannelID])[MessageID].msg = Message
+	(*msgs)[MessageID].msg = Message
 }


### PR DESCRIPTION
Updated the deleted message handler to add an `Update(ChannelID, MessageID disgord.Snowflake, Message *disgord.Message)` function, which allows the cache to be kept upto date and corrected as messages are edited (previously if a message was edited the cache would still represent the message as when it was sent), this also adds an `IgnoreBots` field to the DeletedMessageHandler struct to allow users not to cache bots messages if they choose.

Note: If you use a custom MessageCacheStorageAdapter then this will be a breaking change as it now requires the Update method mentioned previously.