### PR TITLE
Embed menu lifetime

### DIFF
--- a/context.go
+++ b/context.go
@@ -156,9 +156,21 @@ func (c *Context) WaitForMessage(ctx context.Context, CheckFunc func(s disgord.S
 
 // DisplayEmbedMenu is used to allow you to easily display a embed menu.
 func (c *Context) DisplayEmbedMenu(m *EmbedMenu) error {
+	return c.DisplayEmbedMenuWithLifetime(m, nil)
+}
+
+// DisplayEmbedMenuWithLifetime is used to easily display an embed menu with a lifetime.
+func (c *Context) DisplayEmbedMenuWithLifetime(m *EmbedMenu, lifetime *EmbedLifetimeOptions) error {
 	msg, err := c.Reply("Loading...")
 	if err != nil {
 		return err
 	}
-	return m.Display(c.Message.ChannelID, msg.ID, c.Session)
+	err = m.Display(c.Message.ChannelID, msg.ID, c.Session)
+	if err != nil {
+		return err
+	}
+	if lifetime != nil {
+		lifetime.Start(msg.ChannelID, msg.ID, c.Session)
+	}
+	return nil
 }

--- a/default_help_command.go
+++ b/default_help_command.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Creates the embeds for the categories.
@@ -122,7 +123,7 @@ func defaultHelpCommand() *Command {
 			}
 
 			// Send the embed pages.
-			_ = EmbedsPaginator(ctx, pages, uint(page), "Use "+ctx.Prefix+"help <page number> to flick between pages.")
+			_ = EmbedsPaginatorWithLifetime(ctx, pages, uint(page), "Use "+ctx.Prefix+"help <page number> to flick between pages.", &EmbedLifetimeOptions{InactiveLifetime: time.Minute * 5})
 
 			// Return no errors.
 			return nil

--- a/docs/context.md
+++ b/docs/context.md
@@ -19,3 +19,4 @@ It also contains several helper functions:
 - `Reply(data ...interface{}) (*disgord.Message, error)`: A shorter way to quickly reply to a message.
 - `WaitForMessage(ctx context.Context, CheckFunc func(s disgord.Session, msg *disgord.Message) bool) *disgord.Message`: Waits for a message based on the check function you gave.
 - `DisplayEmbedMenu(m *EmbedMenu) error`: Used to display an [embed menu](./embed-menus.md).
+- `DisplayEmbedMenuWithLifetime(m *EmbedMenu, lifetime *EmbedLifetimeOptions) error`: Used to display an [embed menu](./embed-menus.md) and set a maximum lifetime of the menu.

--- a/docs/embed-menus.md
+++ b/docs/embed-menus.md
@@ -11,6 +11,7 @@ menu := gommand.NewEmbedMenu(&disgord.Embed{
 Embed menus have the following functions attached to them:
 
 - `AddBackButton()`: Adds the back button to the embed menu. **Don't use this on the first embed menu, this is meant for child menus.**
+- `AddExitButton()`: Adds an exit button to the menu, causing the menu message to delete. This can be used on any menu.
 - `AddParentMenu(Menu *EmbedMenu)`: Sets the parent of the menu.
 - `Display(ChannelID, MessageID disgord.Snowflake, client disgord.Session) error`: Manually displays the embed. Note that using the `DisplayEmbedMenu` function below should be prefered since it is much easier.
 - `NewChildMenu(options *ChildMenuOptions) *EmbedMenu`: Create a child menu with the options specified. The following options can be set in `ChildMenuOptions`:
@@ -24,9 +25,16 @@ Embed menus also have the `Reactions` attribute attached to them. This contains 
 - `Function func(ChannelID, MessageID disgord.Snowflake, menu *EmbedMenu, client disgord.Session)`: Defines the function that will be called when the button is clicked.
 
 
-The command context has the function `DisplayEmbedMenu` which can be used to easily display the embed. The error defines any issues when it comes to showing the embed:
+The command context has defines two key functions for easily displaying the embed: 
+- `DisplayEmbedMenu(m *EmbedMenu)`: Displays the embed and returns any errors while creating it.
 ```go
 err := ctx.DisplayEmbedMenu(menu)
+```
+- `DisplayEmbedMenuWithLifetime(m *EmbedMenu, lifetime *EmbedLifetimeOptions)`: Displays the embed and allows the usage of [embed lifetimes](#lifetime-options), returning any errors while creating it.
+```go
+err := ctx.DisplayEmbedMenuWithLifetime(menu, &gommand.EmbedLifetimeOptions{
+	MaximumLifetime: time.Minute * 2,
+})
 ```
 
 ## Menu button
@@ -34,3 +42,11 @@ err := ctx.DisplayEmbedMenu(menu)
 - `Emoji`: The unicode emoji that will be used.
 - `Name`: The name of the menu button.
 - `Description`: The description of the menu button.
+
+## Lifetime Options
+`EmbedLifetimeOptions` objects are used to control the maximum duration for which an embed menu will be active / exist. This contains the following attributes:
+- `MaximumLifetime`: The maximum duration the embed should exist for, regardless of activity - optional.
+- `InactiveLifetime`: The maximum duration after the most recent reaction to the menu that the menu should exist for - optional.
+After the duration of either of the above has passed, the menu will be deleted.
+- `BeforeDelete`: The function called when the menu is scheduled to be deleted, but just before the message itself is deleted.
+- `AfterDelete`: The function called after the menu message is deleted, ran regardless of any errors when deleting the message.

--- a/docs/embed-paginator.md
+++ b/docs/embed-paginator.md
@@ -1,6 +1,6 @@
 # Embed Paginator
 
-Gommand contains embed menus, but what if you simply want to create a page system by passing through an array of embeds? Gommand supports the ability to do this with a simple high level API. To do this, we can use the `EmbedsPaginator` function within Gommand. The paginator takes the command [context](./context.md) as the first argument, the array of embeds as the second argument, the initial page number as the third argument (used to flick through pages in the event that the buttons cannot be created) and the text content that will be sent with the embed in the event that the buttons cannot be created as the fourth argument. In the event that this is unable to send, the error result will be set.
+Gommand contains embed menus, but what if you simply want to create a page system by passing through an array of embeds? Gommand supports the ability to do this with a simple high level API. To do this, we can use either the `EmbedsPaginator` or `EmbedsPaginatorWithLifetime` functions within Gommand. Both functions accept the same parameters, except `EmbedsPaginatorWithLifetime` additionally accepts *EmbedLifetimeOptions as the final parameter. The paginator takes the command [context](./context.md) as the first argument, the array of embeds as the second argument, the initial page number as the third argument (used to flick through pages in the event that the buttons cannot be created) and the text content that will be sent with the embed in the event that the buttons cannot be created as the fourth argument. In the event that this is unable to send, the error result will be set.
 ```go
 err := gommand.EmbedsPaginator(ctx, []*disgord.Embed{
     {
@@ -10,4 +10,15 @@ err := gommand.EmbedsPaginator(ctx, []*disgord.Embed{
         Title: "World",
     },
 }, 1, "use command <page number> to flick through pages")
+```
+
+```go
+err := gommand.EmbedsPaginatorWithLifetime(ctx, []*disgord.Embed{
+    {
+        Title: "Hi",
+    },
+    {
+        Title: "World",
+    },
+}, 1, "use command <page number> to flick through pages", &gommand.EmbedLifetimeOptions{InactiveLifetime: time.Minute * 2})
 ```

--- a/embeds_paginator.go
+++ b/embeds_paginator.go
@@ -8,8 +8,9 @@ import (
 	"github.com/andersfylling/disgord"
 )
 
-// EmbedsPaginator is used to paginate together several embeds.
-func EmbedsPaginator(ctx *Context, Pages []*disgord.Embed, InitialPage uint, NoButtonTextContent string) error {
+// EmbedsPaginatorWithLifetime is used to paginate together several embeds, but with an optional *EmbedLifetimeOptions parameter to control the embed lifetime.
+// Passing nil to this parameter indicates no maximum lifetime.
+func EmbedsPaginatorWithLifetime(ctx *Context, Pages []*disgord.Embed, InitialPage uint, NoButtonTextContent string, Lifetime *EmbedLifetimeOptions) (err error) {
 	// Check the permissions which the bot has permission to use embed menus in this channel.
 	c, err := ctx.Channel()
 	if err != nil {
@@ -98,8 +99,16 @@ func EmbedsPaginator(ctx *Context, Pages []*disgord.Embed, InitialPage uint, NoB
 
 	// Return displaying the embed.
 	if UseEmbedMenus {
-		return ctx.DisplayEmbedMenu(DisplayPage)
-	} else {
-		return func() (err error) { _, err = ctx.Reply(NoButtonTextContent, DisplayEmbed); return }()
+		if Lifetime == nil {
+			return ctx.DisplayEmbedMenu(DisplayPage)
+		}
+		return ctx.DisplayEmbedMenuWithLifetime(DisplayPage, Lifetime)
 	}
+	return func() (err error) { _, err = ctx.Reply(NoButtonTextContent, DisplayEmbed); return }()
+
+}
+
+// EmbedsPaginator is used to paginate together several embeds.
+func EmbedsPaginator(ctx *Context, Pages []*disgord.Embed, InitialPage uint, NoButtonTextContent string) error {
+	return EmbedsPaginatorWithLifetime(ctx, Pages, InitialPage, NoButtonTextContent, nil)
 }

--- a/embeds_paginator.go
+++ b/embeds_paginator.go
@@ -24,7 +24,7 @@ func EmbedsPaginatorWithLifetime(ctx *Context, Pages []*disgord.Embed, InitialPa
 	if err != nil {
 		return err
 	}
-	UseEmbedMenus := (perms&disgord.PermissionManageMessages) == disgord.PermissionManageMessages && (perms&disgord.PermissionAddReactions) == disgord.PermissionAddReactions
+	UseEmbedMenus := (perms&disgord.PermissionAdministrator) == disgord.PermissionAdministrator || ((perms&disgord.PermissionManageMessages) == disgord.PermissionManageMessages && (perms&disgord.PermissionAddReactions) == disgord.PermissionAddReactions)
 
 	// Get the pages length.
 	PagesLen := len(Pages)


### PR DESCRIPTION
This PR adds support for menu lifetimes, allowing you to set the maximum time for an embed menu to be responsive, either from its creation or the maximum length of an "inactive" period (defined by no reactions added in that time). After this time has passed, the menu will be deleted, and in the event of an error, automatically removed from the menu cache anyway to stop responding to it. This allows you to stop listening for embeds after it can be presumed they're no longer being used, saving some resources. Functions can be set to be ran before or after the menu is deleted.

I've updated the docs and made changes to preserve backwards compatibility.

This also adds a maximum inactive period of 5 minutes to the default help command.

Also fixes a bug with embed pages where it won't run correctly with the administrator permission, if it doesn't also have manage messages / add reactions.  