### PR TITLE
Update GuildTransformer, and add it to docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,6 +23,7 @@ The command **MUST** have the `Name` (the name of the command) and `Function` (t
         - `gommand.UserTransformer`: Transforms the argument into a user.
         - `gommand.MemberTransformer`: Transforms the argument into a member.
         - `gommand.ChannelTransformer`: Transforms the argument into a channel.
+        - `gommand.GuildTransformer` : Transforms the argument into a guild.
         - `gommand.MessageURLTransformer`: Transforms a message URL into a message.
         - `gommand.BooleanTransformer`: Transforms the argument into a boolean.
         - `gommand.RoleTransformer`: Transforms the argument into a role.

--- a/transformers.go
+++ b/transformers.go
@@ -78,7 +78,11 @@ func ChannelTransformer(ctx *Context, Arg string) (channel interface{}, err erro
 // GuildTransformer is used to transform a guild if possible.
 func GuildTransformer(ctx *Context, Arg string) (guild interface{}, err error) {
 	err = &InvalidTransformation{Description: "This was not a valid guild ID."}
-	guild, e := ctx.Session.GetGuild(context.TODO(), disgord.ParseSnowflakeString(Arg))
+	id, e := strconv.ParseUint(Arg, 10, 64)
+	if e != nil {
+		return
+	}
+	guild, e = ctx.Session.GetGuild(context.TODO(), disgord.NewSnowflake(id))
 	if e == nil {
 		err = nil
 	}


### PR DESCRIPTION
This PR updates GuildTransformer so it no longer uses disgord.ParseSnowflakeString (which panics any errors while transforming) in favour of strconv.ParseUint and disgord.NewSnowflake. While the panicked error is caught, it probably won't be handled properly as it isn't of type InvalidTransformation.