### PR TITLE
Omit help field on reaction menus if the name or description isn't present

### DIFF
--- a/docs/embed-menus.md
+++ b/docs/embed-menus.md
@@ -43,6 +43,8 @@ err := ctx.DisplayEmbedMenuWithLifetime(menu, &gommand.EmbedLifetimeOptions{
 - `Name`: The name of the menu button.
 - `Description`: The description of the menu button.
 
+If the button doesn't include either a `Name` or a `Description`, the help field will be omitted entirely.
+
 ## Lifetime Options
 `EmbedLifetimeOptions` objects are used to control the maximum duration for which an embed menu will be active / exist. This contains the following attributes:
 - `MaximumLifetime`: The maximum duration the embed should exist for, regardless of activity - optional.

--- a/embed_menus.go
+++ b/embed_menus.go
@@ -82,6 +82,10 @@ func (e *EmbedMenu) Display(ChannelID, MessageID disgord.Snowflake, client disgo
 	EmbedCopy := e.Embed.DeepCopy().(*disgord.Embed)
 	Fields := make([]*disgord.EmbedField, 0)
 	for _, k := range e.Reactions.ReactionSlice {
+		if k.Button.Name == "" || k.Button.Description == "" {
+			continue
+		}
+
 		emojiFormatted := k.Button.Emoji
 		if strings.Contains(k.Button.Emoji, ":") {
 			if strings.HasPrefix(k.Button.Emoji, "a:") {


### PR DESCRIPTION
Previously, it was required that `MenuButton` structs had `Name` and `Description` fields. This just adds a check that makes them optional. If one of them isn't present, the entire field is removed.